### PR TITLE
Redirect if only one action in primary sections is visible

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-06-15T07:57:09.720Z\n"
-"PO-Revision-Date: 2023-06-15T07:57:09.720Z\n"
+"POT-Creation-Date: 2023-08-15T11:06:27.074Z\n"
+"PO-Revision-Date: 2023-08-15T11:06:27.074Z\n"
 
 msgid "Field {{field}} cannot be blank"
 msgstr ""
@@ -48,6 +48,9 @@ msgid "Background Color"
 msgstr ""
 
 msgid "Font Color"
+msgstr ""
+
+msgid "Text Alignment"
 msgstr ""
 
 msgid "DHIS2 Compatibility"
@@ -198,6 +201,20 @@ msgid "Field name is mandatory"
 msgstr ""
 
 msgid "Title"
+msgstr ""
+
+msgid ""
+"If only one action in primary sections is visible for a user, an automatic "
+"redirect to that section URL will be performed."
+msgstr ""
+
+msgid "Section visibility mode"
+msgstr ""
+
+msgid "Primary"
+msgstr ""
+
+msgid "Secondary"
 msgstr ""
 
 msgid "Icon Location"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2023-06-15T07:57:09.720Z\n"
+"POT-Creation-Date: 2023-08-15T11:06:27.074Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -48,6 +48,9 @@ msgid "Background Color"
 msgstr ""
 
 msgid "Font Color"
+msgstr ""
+
+msgid "Text Alignment"
 msgstr ""
 
 msgid "DHIS2 Compatibility"
@@ -198,6 +201,20 @@ msgid "Field name is mandatory"
 msgstr ""
 
 msgid "Title"
+msgstr ""
+
+msgid ""
+"If only one action in primary sections is visible for a user, an automatic "
+"redirect to that section URL will be performed."
+msgstr ""
+
+msgid "Section visibility mode"
+msgstr ""
+
+msgid "Primary"
+msgstr ""
+
+msgid "Secondary"
 msgstr ""
 
 msgid "Icon Location"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "home-page",
-    "description": "Home App",
-    "version": "1.5.0",
+    "description": "Home Page App",
+    "version": "1.6.0",
     "license": "GPL-3.0",
     "author": "EyeSeeTea team",
     "homepage": ".",
@@ -122,8 +122,8 @@
         "script-example": "npx ts-node src/scripts/example.ts"
     },
     "manifest.webapp": {
-        "name": "Homepage App",
-        "description": "Homepage App",
+        "name": "Home Page",
+        "description": "Home Page App",
         "icons": {
             "48": "icon.png"
         },

--- a/src/data/repositories/LandingNodeDefaultRepository.ts
+++ b/src/data/repositories/LandingNodeDefaultRepository.ts
@@ -63,6 +63,7 @@ export class LandingNodeDefaultRepository implements LandingNodeRepository {
                     content: undefined,
                     actions: [],
                     backgroundColor: "#276696",
+                    secondary: false,
                 };
 
                 await this.storageClient.saveObject<PersistedLandingNode[][]>(Namespaces.LANDING_PAGES, [[root]]);

--- a/src/webapp/components/action-creation-wizard/steps/GeneralInfoStep.tsx
+++ b/src/webapp/components/action-creation-wizard/steps/GeneralInfoStep.tsx
@@ -152,7 +152,7 @@ export const GeneralInfoStep: React.FC<ActionCreationWizardStepProps> = ({ actio
                 </ColorSelectorContainer>
 
                 <TextAlignmentContainer>
-                    <p>Text Alignment</p>
+                    <p>{i18n.t("Text Alignment")}</p>
 
                     {["left", "center", "right"].map((alignment, i) => (
                         <Button

--- a/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
+++ b/src/webapp/components/landing-page-edit-dialog/LandingPageEditDialog.tsx
@@ -36,6 +36,7 @@ const buildDefaultNode = (
         children: [],
         actions: [],
         backgroundColor: "",
+        secondary: false,
     };
 };
 
@@ -91,6 +92,10 @@ export const LandingPageEditDialog: React.FC<LandingPageEditDialogProps> = props
         setValue(value => ({ ...value, iconLocation: event.target.checked ? "bottom" : "top" }));
     };
 
+    const onChangeSecondary = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setValue(value => ({ ...value, secondary: event.target.checked }));
+    };
+
     const onChangePageRendering = (event: React.ChangeEvent<HTMLInputElement>) => {
         setPageRendering(event.target.checked);
         setValue(value => ({ ...value, pageRendering: event.target.checked ? "single" : "multiple" }));
@@ -136,6 +141,31 @@ export const LandingPageEditDialog: React.FC<LandingPageEditDialogProps> = props
                     onChange={onChangeField("title")}
                 />
             </Row>
+
+            {type === "section" && (
+                <Row style={{ marginBottom: 40 }}>
+                    <h3
+                        title={i18n.t(
+                            "If only one action in primary sections is visible for a user, an automatic redirect to that section URL will be performed."
+                        )}
+                    >
+                        {i18n.t("Section visibility mode")}
+                    </h3>
+
+                    <div>
+                        <IconLocationSwitch>
+                            <p>{i18n.t("Primary")}</p>
+                            <Switch
+                                color="primary"
+                                checked={Boolean(value.secondary)}
+                                onChange={onChangeSecondary}
+                                name="secondary"
+                            />
+                            <p>{i18n.t("Secondary")}</p>
+                        </IconLocationSwitch>
+                    </div>
+                </Row>
+            )}
 
             <Row>
                 <h3>{i18n.t("Icon")}</h3>

--- a/src/webapp/pages/home/HomePage.tsx
+++ b/src/webapp/pages/home/HomePage.tsx
@@ -1,7 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import CircularProgress from "material-ui/CircularProgress";
 import styled from "styled-components";
-import { LandingNode, updateLandingNodes } from "../../../domain/entities/LandingNode";
+import {
+    LandingNode,
+    getPrimaryRedirectUrl as getPrimaryActionUrl,
+    updateLandingNodes,
+} from "../../../domain/entities/LandingNode";
 import i18n from "../../../locales";
 import { LandingLayout, LandingContent } from "../../components/landing-layout";
 import { useAppContext } from "../../contexts/app-context";
@@ -10,6 +14,7 @@ import { Item } from "../../components/item/Item";
 import { useConfig } from "../settings/useConfig";
 import { Cardboard } from "../../components/card-board/Cardboard";
 import { BigCard } from "../../components/card-board/BigCard";
+import { goTo } from "../../utils/routes";
 
 export const HomePage: React.FC = React.memo(() => {
     const { hasSettingsAccess, landings, reload, isLoading, launchAppBaseUrl, translate } = useAppContext();
@@ -79,6 +84,8 @@ export const HomePage: React.FC = React.memo(() => {
         }
     }, [defaultApplication, isLoadingLong, launchAppBaseUrl, userLandings]);
 
+    useRedirectOnSinglePrimaryAction(currentPage);
+
     return (
         <StyledLanding
             backgroundColor={currentPage?.backgroundColor}
@@ -147,3 +154,13 @@ const ContentWrapper = styled.div`
     padding: 15px;
     min-height: 100vh;
 `;
+
+function useRedirectOnSinglePrimaryAction(landingNode: LandingNode | undefined) {
+    const { actions, launchAppBaseUrl } = useAppContext();
+    const { user } = useConfig();
+    const url = user && landingNode ? getPrimaryActionUrl(landingNode, { actions, user }) : undefined;
+
+    React.useEffect(() => {
+        if (url) goTo(url, { baseUrl: launchAppBaseUrl });
+    }, [url, launchAppBaseUrl]);
+}

--- a/src/webapp/utils/routes.ts
+++ b/src/webapp/utils/routes.ts
@@ -1,0 +1,5 @@
+export function goTo(url: string, options: { baseUrl: string }) {
+    const isUrlAbsolute = url.startsWith("http://") || url.startsWith("https://");
+    const href = isUrlAbsolute ? url : options.baseUrl + url;
+    window.location.href = href;
+}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cqytpg

### :memo: Implementation

- Add node.secondary[boolean] (default=false)

### :fire: Testing

docker.eyeseetea.com/eyeseetea/dhis2-data:2.36.11.1-sp-ip-test

- Edit section "DHIS2 Utilities", secondary=true->save, Edit actions so only one APP (for example EFH) is visible -> it should redirect to the app. 
- Otherwise, it should show the tiles.