### PR TITLE
set app namespace in appcontext

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-05-06T08:44:12.108Z\n"
-"PO-Revision-Date: 2024-05-06T08:44:12.108Z\n"
+"POT-Creation-Date: 2024-06-04T15:47:01.351Z\n"
+"PO-Revision-Date: 2024-06-04T15:47:01.351Z\n"
 
 msgid "There are pending migrations"
 msgstr ""
@@ -468,6 +468,9 @@ msgid "First load can take a couple of minutes, please wait..."
 msgstr ""
 
 msgid "Loading the user configuration..."
+msgstr ""
+
+msgid "Available Home Pages"
 msgstr ""
 
 msgid "Create"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-05-06T08:44:12.108Z\n"
+"POT-Creation-Date: 2024-06-04T15:47:01.351Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -468,6 +468,9 @@ msgstr ""
 
 msgid "Loading the user configuration..."
 msgstr ""
+
+msgid "Available Home Pages"
+msgstr "Páginas de inicio disponibles"
 
 msgid "Create"
 msgstr ""

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1,4 +1,5 @@
 declare module "@dhis2/d2-i18n" {
     export function t(value: string, namespace?: object): string;
     export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
 }

--- a/src/webapp/contexts/app-context.tsx
+++ b/src/webapp/contexts/app-context.tsx
@@ -91,6 +91,7 @@ async function getLaunchAppBaseUrl() {
 
 export function useAppContext(): AppContextState {
     const context = useContext(AppContext);
+    i18n.setDefaultNamespace("homepage-app");
     if (context) {
         return context;
     } else {

--- a/src/webapp/pages/home/HomePage.tsx
+++ b/src/webapp/pages/home/HomePage.tsx
@@ -177,7 +177,7 @@ export const HomePage: React.FC = React.memo(() => {
                     </ProgressContainer>
                 ) : initLandings && pageType === "userLandings" ? (
                     <>
-                        <h1>Available Home Pages</h1>
+                        <h1>{i18n.t("Available Home Pages")}</h1>
                         <Cardboard rowSize={4}>
                             {initLandings?.map(landing => {
                                 return (


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694qwkw6

### :memo: Implementation

- [x] Update i18n types
- [x] set default namespace in `app-context.ts`

### The Problem

In our applications we have a `locales/index.js` file that set the namespace for the translations.

```js
const namespace = 'homepage-app';
...
i18n.setDefaultNamespace(namespace);
```

The problem is that we use libraries like `d2-ui-components` or `feedback-component` that also have their own `locale/index.js` files:

```js
const namespace = 'd2-ui-components';
...
i18n.setDefaultNamespace(namespace);
```

so eventually the application namespace will be overwritten by one of these libraries.

### Fast solution

Force the whole application to use the namespace of the app by doing it in the `app-context.ts` file

```ts
i18n.setDefaultNamespace("homepage-app");
```

if you get the error: `Property 'setDefaultNamespace' does not exist on type 'typeof import("@dhis2/d2-i18n")'`
look for the `i18n.d.ts` file and add the type in there:

```ts
declare module "@dhis2/d2-i18n" {
    // ...
    export function setDefaultNamespace(namespace: string);
}
```

### :video_camera: Screenshots/Screen capture

### :fire: Testing

For testing purposes I'm only adding a translation for the string `Available Home Pages`
![image](https://github.com/EyeSeeTea/home-page-app-dev/assets/461124/e5031309-4518-40ea-9616-9ee649a8e7ef)


#8694qwkw6