### PR TITLE
Fix deleted sections on migrations executed

### DIFF
--- a/src/migrations/tasks/02.remove-duplicated-nodes.ts
+++ b/src/migrations/tasks/02.remove-duplicated-nodes.ts
@@ -16,8 +16,11 @@ class RemoveDuplicatedNodesMigration {
             const fixedTrees = landingTrees.map(tree =>
                 tree.reduce<PersistedLandingPage>((acc, node) => {
                     const inParentTree =
-                        node.parent === "none" || node.type === "root" || acc.some(parent => parent.id === node.parent);
-                    const alreadyExist = acc.some(n => n.id === node.id);
+                        node.parent === "none" ||
+                        node.type === "root" ||
+                        tree.some(maybeParent => maybeParent.id === node.parent); // To avoid nodes out of place
+
+                    const alreadyExist = acc.some(n => n.id === node.id); // To avoid duplicated nodes
                     if (inParentTree && !alreadyExist) {
                         return [...acc, node];
                     } else {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8693u555f

### :memo: Implementation

The issue was the bad use of the collection to find wether a node has its parent in the same collection.
- Previously: the accumulator while iterating the tree.
- Now: the tree itself.

### :fire: Testing

[docker.eyeseetea.com/eyeseetea/dhis2-data:2.36.11.1-sp-ip-pro](http://docker.eyeseetea.com/eyeseetea/dhis2-data:2.36.11.1-sp-ip-pro)
[docker.eyeseetea.com/samaritans/dhis2-data:40.3.0-sp-ip-dev](http://docker.eyeseetea.com/samaritans/dhis2-data:40.3.0-sp-ip-dev)