### PR TITLE
hide root header if no title and icon

### DIFF
--- a/src/webapp/components/item-root/ItemRoot.tsx
+++ b/src/webapp/components/item-root/ItemRoot.tsx
@@ -19,19 +19,23 @@ export const ItemRoot: React.FC<{
 
     const rowSize = getNumberActionsToShowPerRow(currentPage.children.length);
 
-    const { title } = useHeaderInfo(currentPage);
+    const { title, showHeader } = useHeaderInfo(currentPage);
 
     return (
         <React.Fragment>
-            {(!currentPage.iconLocation || currentPage.iconLocation === "top") && (
-                <LogoContainer>
-                    <img src={currentPage.icon} alt={logoText} />
-                </LogoContainer>
-            )}
+            {showHeader && (
+                <>
+                    {currentPage.icon && (!currentPage.iconLocation || currentPage.iconLocation === "top") && (
+                        <LogoContainer>
+                            <img src={currentPage.icon} alt={logoText} />
+                        </LogoContainer>
+                    )}
 
-            <LandingTitle bold={true} big={true} color={currentPage.fontColor}>
-                {title}
-            </LandingTitle>
+                    <LandingTitle bold={true} big={true} color={currentPage.fontColor}>
+                        {title}
+                    </LandingTitle>
+                </>
+            )}
 
             <LandingContent>
                 {currentPage.content ? (
@@ -63,7 +67,7 @@ export const ItemRoot: React.FC<{
                 <AdditionalComponents currentPage={currentPage} isRoot={isRoot} openPage={openPage} />
             </LandingContent>
 
-            {currentPage.iconLocation === "bottom" && (
+            {currentPage.icon && currentPage.iconLocation === "bottom" && (
                 <LogoContainer>
                     <img src={currentPage.icon} alt={logoText} />
                 </LogoContainer>

--- a/src/webapp/hooks/useHeaderInfo.ts
+++ b/src/webapp/hooks/useHeaderInfo.ts
@@ -4,7 +4,7 @@ import { useAppContext } from "../contexts/app-context";
 export function useHeaderInfo(currentPage: LandingNode) {
     const { translate } = useAppContext();
 
-    const title = currentPage.title ? translate(currentPage.title) : undefined;
+    const title = currentPage.title?.referenceValue.trim() ? translate(currentPage.title) : undefined;
     const showHeader = currentPage.icon || title;
 
     return {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869auq278 [HomePageApp: Remove 'blank' space at the top for NHWA Homepage](https://app.clickup.com/t/869auq278)

### :memo: Implementation
- hide root landing page if no title and icon

### :video_camera: Screenshots/Screen capture
<img width="1466" height="659" alt="image" src="https://github.com/user-attachments/assets/498345ae-4487-4782-9e5a-a1400445c7ec" />

"hidden" header due to white background + white font
<img width="1477" height="674" alt="image" src="https://github.com/user-attachments/assets/b63e4ed0-30a0-47bd-b3dd-9743c932ae77" />


### :fire: Testing
