### PR TITLE
add v42 to compatibility list

### DIFF
--- a/src/webapp/components/action-creation-wizard/steps/GeneralInfoStep.tsx
+++ b/src/webapp/components/action-creation-wizard/steps/GeneralInfoStep.tsx
@@ -314,4 +314,5 @@ const dhisVersions = [
     { value: "2.39", text: "2.39" },
     { value: "2.40", text: "2.40" },
     { value: "2.41", text: "2.41" },
+    { value: "2.42", text: "2.42" },
 ];


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869beeny2 #869beeny2

### :memo: Implementation

- [x] add v42 to compatibility list 

Migration for CPR: 

- [x] Update compatibility for all the actions from: v40 to v42
- [x] For some reason the option "Show list with Actions on main landing page" was disabled so I had to enable it in the VPN server.
- [x] Change the order of actions from: LearnOCC, Downloads, CPR to LearnOCC, CPR, Downloads


### :video_camera: Screenshots/Screen capture

<img width="1828" height="771" alt="image" src="https://github.com/user-attachments/assets/30b69287-4e5b-479f-b17a-5936bcb0f2a1" />

<img width="1313" height="922" alt="image" src="https://github.com/user-attachments/assets/bb009f6c-2600-464c-9515-fd9fe906c34a" />


### :fire: Testing
