### PR TITLE
Translate action description and import per-action

### DIFF
--- a/i18n/ar.po
+++ b/i18n/ar.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-02-05T16:47:42.188Z\n"
+"POT-Creation-Date: 2026-05-06T08:40:59.606Z\n"
 "PO-Revision-Date: 2025-06-06T19:59:41.289Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -246,10 +246,10 @@ msgstr ""
 msgid "Export JSON translations"
 msgstr ""
 
-msgid "Import actions"
+msgid "Import JSON translations"
 msgstr ""
 
-msgid "Import JSON translations"
+msgid "Import actions"
 msgstr ""
 
 msgid "App/Link"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-02-05T16:47:42.188Z\n"
-"PO-Revision-Date: 2026-02-05T16:47:42.188Z\n"
+"POT-Creation-Date: 2026-05-06T08:40:59.606Z\n"
+"PO-Revision-Date: 2026-05-06T08:40:59.606Z\n"
 
 msgid "There are pending migrations"
 msgstr ""
@@ -245,10 +245,10 @@ msgstr ""
 msgid "Export JSON translations"
 msgstr ""
 
-msgid "Import actions"
+msgid "Import JSON translations"
 msgstr ""
 
-msgid "Import JSON translations"
+msgid "Import actions"
 msgstr ""
 
 msgid "App/Link"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-02-05T16:47:42.188Z\n"
+"POT-Creation-Date: 2026-05-06T08:40:59.606Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -245,10 +245,10 @@ msgstr ""
 msgid "Export JSON translations"
 msgstr ""
 
-msgid "Import actions"
+msgid "Import JSON translations"
 msgstr ""
 
-msgid "Import JSON translations"
+msgid "Import actions"
 msgstr ""
 
 msgid "App/Link"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-02-05T16:47:42.188Z\n"
+"POT-Creation-Date: 2026-05-06T08:40:59.606Z\n"
 "PO-Revision-Date: 2025-06-06T19:59:41.289Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -245,10 +245,10 @@ msgstr ""
 msgid "Export JSON translations"
 msgstr ""
 
-msgid "Import actions"
+msgid "Import JSON translations"
 msgstr ""
 
-msgid "Import JSON translations"
+msgid "Import actions"
 msgstr ""
 
 msgid "App/Link"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-02-05T16:47:42.188Z\n"
+"POT-Creation-Date: 2026-05-06T08:40:59.606Z\n"
 "PO-Revision-Date: 2025-06-06T19:59:41.289Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -246,10 +246,10 @@ msgstr ""
 msgid "Export JSON translations"
 msgstr ""
 
-msgid "Import actions"
+msgid "Import JSON translations"
 msgstr ""
 
-msgid "Import JSON translations"
+msgid "Import actions"
 msgstr ""
 
 msgid "App/Link"

--- a/i18n/zh.po
+++ b/i18n/zh.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-02-05T16:47:42.188Z\n"
+"POT-Creation-Date: 2026-05-06T08:40:59.606Z\n"
 "PO-Revision-Date: 2025-06-06T19:59:41.289Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -245,10 +245,10 @@ msgstr ""
 msgid "Export JSON translations"
 msgstr ""
 
-msgid "Import actions"
+msgid "Import JSON translations"
 msgstr ""
 
-msgid "Import JSON translations"
+msgid "Import actions"
 msgstr ""
 
 msgid "App/Link"

--- a/src/data/repositories/ActionDefaultRepository.ts
+++ b/src/data/repositories/ActionDefaultRepository.ts
@@ -135,7 +135,7 @@ export class ActionDefaultRepository implements ActionRepository {
 
         await this.saveDataStore(translatedModel);
 
-        const translations = await this.extractTranslations(model);
+        const translations = await this.extractTranslations(translatedModel);
         return _.intersection(_.keys(translations["en"]), _.keys(terms)).length;
     }
 

--- a/src/data/repositories/ActionDefaultRepository.ts
+++ b/src/data/repositories/ActionDefaultRepository.ts
@@ -124,6 +124,13 @@ export class ActionDefaultRepository implements ActionRepository {
         const translatedModel: PersistedAction = {
             ...model,
             name: setTranslationValue({ item: model.name, language, term: terms[model.name.key] }),
+            description: model.description
+                ? setTranslationValue({
+                      item: model.description,
+                      language,
+                      term: terms[model.description.key],
+                  })
+                : model.description,
         };
 
         await this.saveDataStore(translatedModel);
@@ -133,7 +140,7 @@ export class ActionDefaultRepository implements ActionRepository {
     }
 
     private async extractTranslations(model: PersistedAction): Promise<Record<string, Record<string, string>>> {
-        const texts = _.compact([model.name]);
+        const texts = _.compact([model.name, model.description]);
 
         const referenceStrings = _.fromPairs(texts.map(({ key, referenceValue }) => [key, referenceValue]));
         const translatedStrings = _(texts)

--- a/src/webapp/components/action-list-table/ActionListTable.tsx
+++ b/src/webapp/components/action-list-table/ActionListTable.tsx
@@ -44,6 +44,7 @@ export const ActionListTable: React.FC<ActionListTableProps> = props => {
     const translationImportRef = useRef<ImportTranslationRef>(null);
 
     const [selection, setSelection] = useState<TableSelection[]>([]);
+    const [actionIdForImport, setActionIdForImport] = useState<string>();
 
     const [dialogProps, updateDialog] = useState<ConfirmationDialogProps | null>(null);
 
@@ -70,16 +71,16 @@ export const ActionListTable: React.FC<ActionListTableProps> = props => {
     );
 
     const handleTranslationUpload = useCallback(
-        async (key: string | undefined, lang: string, terms: Record<string, string>) => {
-            if (!key) return;
-            const total = await compositionRoot.actions.importTranslations(key, lang, terms);
+        async (lang: string, terms: Record<string, string>) => {
+            if (!actionIdForImport) return;
+            const total = await compositionRoot.actions.importTranslations(actionIdForImport, lang, terms);
             if (total > 0) {
                 snackbar.success(i18n.t("Imported {{total}} translation terms", { total }));
             } else {
                 snackbar.warning(i18n.t("Unable to import translation terms"));
             }
         },
-        [compositionRoot, snackbar]
+        [actionIdForImport, compositionRoot, snackbar]
     );
 
     const deleteActions = useCallback(
@@ -204,8 +205,10 @@ export const ActionListTable: React.FC<ActionListTableProps> = props => {
     );
 
     const importTranslations = useCallback((ids: string[]) => {
-        if (!ids[0]) return;
-        translationImportRef.current?.startImport(ids[0]);
+        const id = ids[0];
+        if (!id) return;
+        setActionIdForImport(id);
+        translationImportRef.current?.startImport();
     }, []);
 
     const onTableChange = useCallback(({ selection }: TableState<ListItem>) => {
@@ -382,7 +385,7 @@ export const ActionListTable: React.FC<ActionListTableProps> = props => {
         <PageWrapper>
             {dialogProps && <ConfirmationDialog isOpen={true} maxWidth={"xl"} {...dialogProps} />}
 
-            <ImportTranslationDialog type="action" ref={translationImportRef} onSave={handleTranslationUpload} />
+            <ImportTranslationDialog ref={translationImportRef} onSave={handleTranslationUpload} />
 
             <Dropzone ref={actionImportRef} accept={zipMimeType} onDrop={handleFileUpload}>
                 <ObjectsTable<ListItem>

--- a/src/webapp/components/action-list-table/ActionListTable.tsx
+++ b/src/webapp/components/action-list-table/ActionListTable.tsx
@@ -203,6 +203,11 @@ export const ActionListTable: React.FC<ActionListTableProps> = props => {
         [loading, compositionRoot]
     );
 
+    const importTranslations = useCallback((ids: string[]) => {
+        if (!ids[0]) return;
+        translationImportRef.current?.startImport(ids[0]);
+    }, []);
+
     const onTableChange = useCallback(({ selection }: TableState<ListItem>) => {
         setSelection(selection);
     }, []);
@@ -338,6 +343,13 @@ export const ActionListTable: React.FC<ActionListTableProps> = props => {
                 onClick: exportTranslations,
                 multiple: false,
             },
+            {
+                name: "import-translations",
+                text: i18n.t("Import JSON translations"),
+                icon: <Icon>translate</Icon>,
+                onClick: importTranslations,
+                multiple: false,
+            },
         ],
         [
             tableActions,
@@ -350,6 +362,7 @@ export const ActionListTable: React.FC<ActionListTableProps> = props => {
             addAction,
             exportAction,
             exportTranslations,
+            importTranslations,
         ]
     );
 
@@ -361,16 +374,8 @@ export const ActionListTable: React.FC<ActionListTableProps> = props => {
                 icon: <Icon>arrow_upward</Icon>,
                 onClick: openImportDialog,
             },
-            {
-                name: "import-translations",
-                text: i18n.t("Import JSON translations"),
-                icon: <Icon>translate</Icon>,
-                onClick: () => {
-                    translationImportRef.current?.startImport();
-                },
-            },
         ],
-        [openImportDialog, translationImportRef]
+        [openImportDialog]
     );
 
     return (

--- a/src/webapp/components/import-translation-dialog/ImportTranslationDialog.tsx
+++ b/src/webapp/components/import-translation-dialog/ImportTranslationDialog.tsx
@@ -15,12 +15,15 @@ export const ImportTranslationDialog = React.forwardRef(
         const [open, setOpen] = useState<boolean>(false);
         const [selectedLang, setSelectedLang] = useState<string>();
         const [selectedAction, setSelectedAction] = useState<string>();
+        const [presetActionId, setPresetActionId] = useState<string>();
         const [terms, setTerms] = useState<Record<string, string>>();
 
         const inputRef = useRef<any>(null);
 
+        const effectiveActionId = presetActionId ?? selectedAction;
+
         const save = useCallback(async () => {
-            if (props.type === "action" && !selectedAction) {
+            if (props.type === "action" && !effectiveActionId) {
                 snackbar.error(i18n.t("You need to select an action"));
                 return;
             }
@@ -29,10 +32,10 @@ export const ImportTranslationDialog = React.forwardRef(
                 snackbar.error(i18n.t("You need to select a language"));
                 return;
             }
-            await props.onSave(selectedAction, selectedLang, terms);
+            await props.onSave(effectiveActionId, selectedLang, terms);
 
             setOpen(false);
-        }, [snackbar, props, selectedAction, selectedLang, terms]);
+        }, [snackbar, props, effectiveActionId, selectedLang, terms]);
 
         const onFileUpload = useCallback(
             async (event: any) => {
@@ -58,7 +61,9 @@ export const ImportTranslationDialog = React.forwardRef(
         );
 
         useImperativeHandle(ref, () => ({
-            startImport() {
+            startImport(actionId?: string) {
+                setPresetActionId(actionId);
+                setSelectedAction(undefined);
                 inputRef.current.click();
             },
         }));
@@ -83,7 +88,7 @@ export const ImportTranslationDialog = React.forwardRef(
                     fullWidth={true}
                 >
                     <Container>
-                        {props.type === "action" ? (
+                        {props.type === "action" && !presetActionId ? (
                             <Select
                                 label={i18n.t("Action to add translation")}
                                 items={buildActionList(actions, translate)}
@@ -115,7 +120,7 @@ const Select = styled(Dropdown)`
 `;
 
 export interface ImportTranslationRef {
-    startImport: () => void;
+    startImport: (actionId?: string) => void;
 }
 
 export interface ImportTranslationDialogProps {

--- a/src/webapp/components/import-translation-dialog/ImportTranslationDialog.tsx
+++ b/src/webapp/components/import-translation-dialog/ImportTranslationDialog.tsx
@@ -1,46 +1,43 @@
-import { ConfirmationDialog, Dropdown, DropdownItem, useSnackbar } from "@eyeseetea/d2-ui-components";
+import { ConfirmationDialog, Dropdown, useSnackbar } from "@eyeseetea/d2-ui-components";
 import _ from "lodash";
 import React, { useCallback, useImperativeHandle, useRef, useState } from "react";
 import styled from "styled-components";
-import { Action } from "../../../domain/entities/Action";
-import { TranslateMethod } from "../../../domain/entities/TranslatableText";
 import i18n from "../../../utils/i18n";
-import { useAppContext } from "../../contexts/app-context";
 
 export const ImportTranslationDialog = React.forwardRef(
     (props: ImportTranslationDialogProps, ref: React.ForwardedRef<ImportTranslationRef>) => {
-        const { actions, translate } = useAppContext();
         const snackbar = useSnackbar();
 
         const [open, setOpen] = useState<boolean>(false);
         const [selectedLang, setSelectedLang] = useState<string>();
-        const [selectedAction, setSelectedAction] = useState<string>();
-        const [presetActionId, setPresetActionId] = useState<string>();
         const [terms, setTerms] = useState<Record<string, string>>();
 
-        const inputRef = useRef<any>(null);
+        const inputRef = useRef<HTMLInputElement>(null);
 
-        const effectiveActionId = presetActionId ?? selectedAction;
+        const reset = useCallback(() => {
+            setSelectedLang(undefined);
+            setTerms(undefined);
+        }, []);
+
+        const close = useCallback(() => {
+            setOpen(false);
+            reset();
+        }, [reset]);
 
         const save = useCallback(async () => {
-            if (props.type === "action" && !effectiveActionId) {
-                snackbar.error(i18n.t("You need to select an action"));
-                return;
-            }
-
             if (!selectedLang || !terms) {
                 snackbar.error(i18n.t("You need to select a language"));
                 return;
             }
-            await props.onSave(effectiveActionId, selectedLang, terms);
+            await props.onSave(selectedLang, terms);
 
-            setOpen(false);
-        }, [snackbar, props, effectiveActionId, selectedLang, terms]);
+            close();
+        }, [snackbar, props, selectedLang, terms, close]);
 
         const onFileUpload = useCallback(
-            async (event: any) => {
+            async (event: React.ChangeEvent<HTMLInputElement>) => {
                 try {
-                    const file = event.target.files[0];
+                    const file = event.target.files?.[0];
                     if (!file) throw new Error("No file received on upload");
 
                     const text = await file.text();
@@ -61,10 +58,8 @@ export const ImportTranslationDialog = React.forwardRef(
         );
 
         useImperativeHandle(ref, () => ({
-            startImport(actionId?: string) {
-                setPresetActionId(actionId);
-                setSelectedAction(undefined);
-                inputRef.current.click();
+            startImport() {
+                inputRef.current?.click();
             },
         }));
 
@@ -83,20 +78,11 @@ export const ImportTranslationDialog = React.forwardRef(
                     title={i18n.t("Import translation")}
                     open={open}
                     onSave={save}
-                    onCancel={() => setOpen(false)}
+                    onCancel={close}
                     maxWidth={"md"}
                     fullWidth={true}
                 >
                     <Container>
-                        {props.type === "action" && !presetActionId ? (
-                            <Select
-                                label={i18n.t("Action to add translation")}
-                                items={buildActionList(actions, translate)}
-                                onChange={setSelectedAction}
-                                value={selectedAction}
-                            />
-                        ) : null}
-
                         <Select
                             label={i18n.t("Language to add translation")}
                             items={languages}
@@ -119,18 +105,13 @@ const Select = styled(Dropdown)`
     margin: 10px;
 `;
 
-export interface ImportTranslationRef {
-    startImport: (actionId?: string) => void;
-}
+export type ImportTranslationRef = {
+    startImport: () => void;
+};
 
-export interface ImportTranslationDialogProps {
-    type: "action" | "landing-page" | "notification";
-    onSave: (key: string | undefined, lang: string, terms: Record<string, string>) => void | Promise<void>;
-}
-
-function buildActionList(actions: Action[], translate: TranslateMethod): DropdownItem[] {
-    return actions.map(({ id, name }) => ({ value: id, text: translate(name) }));
-}
+export type ImportTranslationDialogProps = {
+    onSave: (lang: string, terms: Record<string, string>) => void | Promise<void>;
+};
 
 const languages = [
     { value: "ab", text: "Abkhazian" },

--- a/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
+++ b/src/webapp/components/landing-page-list-table/LandingPageListTable.tsx
@@ -97,7 +97,7 @@ export const LandingPageListTable: React.FC<{ nodes: LandingNode[]; isLoading?: 
     );
 
     const handleTranslationUpload = useCallback(
-        async (_key: string | undefined, lang: string, terms: Record<string, string>) => {
+        async (lang: string, terms: Record<string, string>) => {
             const total = await compositionRoot.landings.importTranslations(lang, terms, landingPageId);
             if (total > 0) {
                 snackbar.success(i18n.t("Imported {{total}} translation terms", { total }));
@@ -396,7 +396,7 @@ export const LandingPageListTable: React.FC<{ nodes: LandingNode[]; isLoading?: 
                     onClose={closeSettings}
                 />
             )}
-            <ImportTranslationDialog type="landing-page" ref={translationImportRef} onSave={handleTranslationUpload} />
+            <ImportTranslationDialog ref={translationImportRef} onSave={handleTranslationUpload} />
 
             <Dropzone
                 ref={landingImportRef}

--- a/src/webapp/components/notifications/NotificationListTable.tsx
+++ b/src/webapp/components/notifications/NotificationListTable.tsx
@@ -70,7 +70,7 @@ export const NotificationListTable: React.FC<NotificationListTableProps> = props
         <PageWrapper>
             {confirmDeleteProps && <ConfirmationDialog {...confirmDeleteProps} />}
             {permissionsDialogProps && <PermissionsDialog {...permissionsDialogProps} />}
-            <ImportTranslationDialog type="notification" ref={translationImportRef} onSave={handleTranslationUpload} />
+            <ImportTranslationDialog ref={translationImportRef} onSave={handleTranslationUpload} />
             <ObjectsTable<NotificationViewModel>
                 rows={notifications}
                 columns={columns}

--- a/src/webapp/components/notifications/useImportExportNotificationTranslation.ts
+++ b/src/webapp/components/notifications/useImportExportNotificationTranslation.ts
@@ -9,7 +9,7 @@ export function useImportExportNotificationTranslation(fetchNotifications: () =>
     const loading = useLoading();
 
     const handleTranslationUpload = useCallback(
-        async (_key: string | undefined, lang: string, terms: Record<string, string>) => {
+        async (lang: string, terms: Record<string, string>) => {
             const total = await compositionRoot.notification.importTranslations(lang, terms).toPromise();
             if (total > 0) {
                 snackbar.success(i18n.t("Imported translations for {{total}} notification/s", { total }));


### PR DESCRIPTION
Closes: https://app.clickup.com/t/869d697pd 

## Summary
- Include action **description** in the JSON translation export/import flow (was silently limited to `name`, so `action-description` never appeared in the exported JSON and was ignored on import).
- Move **Import JSON translations** from the global toolbar to a per-row action (next to "Export JSON translations") and pre-select that row's action in the import dialog. The global entry is removed.

## Test plan
- [ ] Open an action with a non-empty description, run **Export JSON translations**: the JSON inside the ZIP contains both `action-name` and `action-description` keys.
- [ ] Translate the file, then on the same row click **Import JSON translations**, pick the language, confirm: both name and description are stored as translations and rendered in that locale.
- [ ] On a legacy action without a stored `description`, export still works and import does not throw.
- [ ] The global "Import JSON translations" button no longer appears; the per-row entry does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)